### PR TITLE
WDP190404-7 --> Add hover to select category

### DIFF
--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -58,9 +58,6 @@
               <i class="fas fa-list-ul"></i>
               <select name="" id="">
                 <option value="">Select a category</option>
-                <option value="">category</option>
-                <option value="">Select a category</option>
-                <option value="">Select a category</option>
               </select>
               <i class="fas fa-caret-down"></i>
             </div>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -58,6 +58,9 @@
               <i class="fas fa-list-ul"></i>
               <select name="" id="">
                 <option value="">Select a category</option>
+                <option value="">category</option>
+                <option value="">Select a category</option>
+                <option value="">Select a category</option>
               </select>
               <i class="fas fa-caret-down"></i>
             </div>

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -7,5 +7,6 @@ $footer-bg: #363636;
 $primary: #d58e32;
 
 $text-color: #2a2a2a;
+$text-color-hover: #ffffff;
 
 $form-border-color: #292929;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -172,8 +172,11 @@ header {
         align-items: center;
         position: relative;
 
-        i:first-child {
+        &:hover i:first-child {
           color: $primary;
+        }
+
+        i:first-child {
           position: absolute;
           left: 10px;
           z-index: 0;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -172,8 +172,16 @@ header {
         align-items: center;
         position: relative;
 
-        &:hover i:first-child {
-          color: $primary;
+        &:hover {
+          background: $primary;
+          & i:first-child,
+          i:last-child,
+          select {
+            color: $text-color-hover;
+            option {
+              color: $form-border-color;
+            }
+          }
         }
 
         i:first-child {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -174,10 +174,12 @@ header {
 
         &:hover {
           background: $primary;
-          & i:first-child,
+
+          i:first-child,
           i:last-child,
           select {
             color: $text-color-hover;
+
             option {
               color: $form-border-color;
             }


### PR DESCRIPTION
**Opis:**
Select nie jest prawidłowo ostylowany: Zostaje outline po zmianie kategorii. Brak hoverów.
Do poprawy wedle designu. 

**Rozwiązanie:**
_header.scss 
Dodałem hover do .category działający na ikonę wyboru (first-child)

**UWAGI:**
W .select był już outline: none;
Przy testach otoczka nie zostawała po wyborze kategorii.
Występowało to przy usuniętej linii outline: none;
W PSD nie było pokazane jak ma się zachowywać wybór kategorii po rozwinięciu. Natomiast ostylowanie będzie wykonane przy kroku WDP190404-10 gdzie select będzie zmieniany na ul-->li