### PR TITLE
WDP190404-11 RWD main menu

### DIFF
--- a/src/furniture.html
+++ b/src/furniture.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Furnitures shop</title>
+    <link rel="stylesheet" href="./sass/style.scss" />
+  </head>
+
+  <body>
+    <module href="./src/partials/10_header.html"></module>
+    <module href="./src/partials/120_section-promotion.html"></module>
+    <module href="./src/partials/130_section-all-furniture.html"></module>
+
+    <module href="./src/partials/90_footer.html"></module>
+
+    <script src="./scripts/bootstrap.min.js"></script>
+    <script src="./scripts/furniture.js"></script>
+  </body>
+</html>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -90,6 +90,8 @@
             </div>
           </form>
         </div>
+        <label for="menuSwitch"><i class="fas fa-bars"></i></label>
+        <input class="menu-switch" id="menuSwitch" type="checkbox" value="false" />
         <div class="col-auto menu">
           <ul>
             <li><a href="#" class="active">Home</a></li>

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -10,3 +10,8 @@ $text-color: #2a2a2a;
 $text-color-hover: #ffffff;
 
 $form-border-color: #292929;
+
+$maxSmall: 767px;
+$minMedium: 768px;
+$maxMedium: 1199px;
+$minLarge: 1200px;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -142,6 +142,10 @@ header {
     .menu {
       display: flex;
       align-self: stretch;
+      @media (max-width: $maxMedium) {
+        margin-bottom: 5px;
+      }
+
       @media (max-width: $maxSmall) {
         width: 100%;
       }
@@ -231,7 +235,7 @@ header {
             }
           }
         }
-        
+
         @media (max-width: $maxSmall) {
           justify-content: center;
           height: 45px;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -119,23 +119,50 @@ header {
     box-shadow: 2px 3.464px 6px rgba(1, 2, 2, 0.2);
     background-color: #ffffff;
 
+    @media (max-width: $maxMedium) {
+      .container {
+        padding: 0;
+      }
+    }
+
     .container > .row {
       height: 84px;
+      @media (max-width: $maxMedium) {
+        flex-direction: column-reverse;
+        height: 110px;
+      }
+
+      @media (max-width: $maxSmall) {
+        flex-direction: row;
+        padding: 10px;
+        width: 100%;
+      }
     }
 
     .menu {
       display: flex;
       align-self: stretch;
+      @media (max-width: $maxSmall) {
+        width: 100%;
+      }
 
       ul {
         margin: 0;
         padding: 0;
         display: flex;
+        @media (max-width: $maxSmall) {
+          flex-direction: column;
+          height: 110px;
+          width: 100%;
+        }
 
         li {
           list-style: none;
           display: flex;
           align-items: stretch;
+          @media (max-width: $maxSmall) {
+            width: 100%;
+          }
 
           a {
             color: $text-color;
@@ -149,6 +176,13 @@ header {
             font-weight: 500;
             letter-spacing: 1px;
             @extend %hover-background-animation;
+
+            @media (max-width: $maxSmall) {
+              width: 100%;
+              justify-content: center;
+              background: #ffffff;
+              z-index: 10;
+            }
 
             &:hover,
             &.active {
@@ -170,7 +204,13 @@ header {
       display: inline-flex;
       height: 45px;
       color: $text-color;
-
+      @media (max-width: $maxSmall) {
+        display: flex;
+        border: none;
+        flex-direction: column;
+        width: 90%;
+        height: 90px;
+      }
       .category {
         border-right: 1px solid $form-border-color;
         display: flex;
@@ -190,6 +230,12 @@ header {
               color: $form-border-color;
             }
           }
+        }
+        
+        @media (max-width: $maxSmall) {
+          justify-content: center;
+          height: 45px;
+          border: 1px solid $form-border-color;
         }
 
         i:first-child {
@@ -271,12 +317,21 @@ header {
         display: flex;
         align-items: center;
         position: relative;
+        @media (max-width: $maxSmall) {
+          justify-content: center;
+          height: 45px;
+          border: 1px solid $form-border-color;
+          border-top: none;
+        }
 
         input {
           border: 0;
           padding-left: 10px;
           font-size: 14px;
           outline: none;
+          @media (max-width: $maxSmall) {
+            width: 90%;
+          }
 
           &::placeholder {
             color: $text-color;
@@ -287,6 +342,34 @@ header {
           border: 0;
           background-color: transparent;
           outline: none;
+        }
+      }
+    }
+
+    .menu-switch {
+      display: none;
+    }
+
+    label {
+      display: none;
+    }
+
+    @media (max-width: $maxSmall) {
+      label {
+        display: block;
+      }
+
+      .menu-switch {
+        & ~ .menu {
+          padding: 10px;
+        }
+
+        &:checked ~ .menu {
+          display: flex;
+        }
+
+        &:not(:checked) ~ .menu {
+          display: none;
         }
       }
     }


### PR DESCRIPTION
**Opis:**
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Ten task dotyczy menu głównego (wyszukiwanie i "Home", etc.) 

Na tabletach wyszukiwanie ma być pod menu, a na mniejszych ekranach ma być wyszukiwanie i obok niego ikona mobilnego menu, które po rozwinięciu ma pokazywać dropdown przykrywający treść strony

**Problem:**
Brak RWD

**Rozwiązanie:**
Dodanie do _variables.scss zmiennych do RWD

10_header.html --> dodanie checkboxa + label

_header.scss --> RWD menu